### PR TITLE
Call header_remove only when the function exists (it's 5.3+)

### DIFF
--- a/core/components/phpthumbsup/model/phpthumbsup/phpthumbsup.class.php
+++ b/core/components/phpthumbsup/model/phpthumbsup/phpthumbsup.class.php
@@ -450,7 +450,9 @@ class PhpThumbsUp {
         header('Last-Modified: '. $last_modified);
 
         // Expires shouldn't be set by default
-        header_remove('Expires');
+        if (function_exists('header_remove')) {
+            header_remove('Expires');
+        }
 
         readfile($file);
     }


### PR DESCRIPTION
Probably the only thing blocking usage on PHP 5.2 (yes, it sucks, but i was forced to use shared webhosting w/o 5.3+).
