### PR TITLE
Support (sub)domain for processing images

### DIFF
--- a/core/components/phpthumbsup/model/phpthumbsup/phpthumbsup.class.php
+++ b/core/components/phpthumbsup/model/phpthumbsup/phpthumbsup.class.php
@@ -153,6 +153,15 @@ class PhpThumbsUp {
             //$url = ltrim($_REQUEST['q'], '/');
             $url = ltrim($_SERVER['REQUEST_URI'], '/');
             $base_url = ltrim($this->config['baseUrl'], '/');
+            
+            // when base url contains http(s):// url
+            if(stripos($base_url, 'http') === 0) {
+                $base_url = str_replace(array('http://','https://'), '', $base_url);
+                if(stripos($base_url, $_SERVER['HTTP_HOST']) === 0) {
+                    $base_url = ltrim(str_replace($_SERVER['HTTP_HOST'], '', $base_url), '/');
+                }
+            }
+            
             if (strpos($url, $base_url) === 0) {
                 $options = $this->get_options($url, $base_url);
                 if (count($options) == 1 && !empty($options['src'])) {


### PR DESCRIPTION
This update allows you to use another (sub)domain for the images requests. This is useful when it comes to loading speed on a website with several requests. You can setup the system setting "base_url" with a full URL.
The only required thing is, after the domain; you should keep something like "phpthumbsup/" as fictive part of the URL. 
Also besides that, the (sub)domain should point to your MODX installation too. Because it needs MODX to run the code.
